### PR TITLE
Fix TypeError in MCP tool lookup when clientsMap is undefined

### DIFF
--- a/app/src/agent/tools/mcp/index.ts
+++ b/app/src/agent/tools/mcp/index.ts
@@ -37,6 +37,9 @@ export const getMcpToolSpecs = async (workerId: string, config: McpConfig): Prom
 };
 
 export const tryExecuteMcpTool = async (workerId: string, toolName: string, input: any) => {
+  if (!clientsMap[workerId]) {
+    return { found: false };
+  }
   const client = clientsMap[workerId].find(({ client }) =>
     client.tools.find((tool) => tool.toolSpec?.name == toolName)
   );


### PR DESCRIPTION
- Add null check for clientsMap[workerId] before calling .find()
- Prevents session crashes when tool calls are made but MCP isn't initialized
- Returns { found: false } to gracefully fall back to built-in tools

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
